### PR TITLE
add support for Token2022 destinations

### DIFF
--- a/programs/bridge_cards/src/instructions/add_or_update_merchant_destination.rs
+++ b/programs/bridge_cards/src/instructions/add_or_update_merchant_destination.rs
@@ -3,8 +3,7 @@ use crate::instructions::initialize::STATE_SEED;
 use crate::state::{BridgeCardsState, MerchantDestinationState};
 use crate::ID;
 use anchor_lang::prelude::*;
-use anchor_spl::token::TokenAccount;
-use anchor_spl::token_interface::Mint;
+use anchor_spl::token_interface::{Mint, TokenAccount};
 
 /// Seed used to derive merchant destination PDAs
 pub const MERCHANT_DESTINATION_SEED: &[u8] = b"merchant_destination";
@@ -90,7 +89,7 @@ pub struct AddOrUpdateMerchantDestination<'info> {
     /// Must use the specified mint
     /// Required permissions: None (read-only validation)
     #[account(constraint = destination_token_account.mint.key() == mint.key())]
-    pub destination_token_account: Account<'info, TokenAccount>,
+    pub destination_token_account: InterfaceAccount<'info, TokenAccount>,
 
     /// Mint of the destination token account
     /// Used for PDA derivation and account validation


### PR DESCRIPTION
The `destination_token_account` is a `Account<'info, TokenAccount>`.  

Because `Account` only supports `TokenProgram`, when I tried to initialize the destination for USDP, it failed with the following error:

```
Error Code: AccountOwnedByWrongProgram
Left: TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb (Token2022)  
Right: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (Token)
```

DebitUser uses `InterfaceAccount<'info, TokenAccount>` for the destination account, so we should allow merchant destination of the same type