### PR TITLE
parameterizes all tests for token22

### DIFF
--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -26,7 +26,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy
 
   anchor-test:
     name: Run Anchor Tests

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust-checks.yml
+++ b/.github/workflows/rust-checks.yml
@@ -26,7 +26,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy
+        run: cargo clippy -- -D warnings
 
   anchor-test:
     name: Run Anchor Tests

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -35,6 +35,6 @@ wallet = "~/.config/solana/id.json"
 url = "http://127.0.0.1:8899"
 
 [scripts]
-test = "cargo test"
-initialize = "ts-node scripts/initialize.ts"
 build = "export PROGRAM_ID=$(solana-keygen pubkey program-keypair.json) && anchor build"
+initialize = "ts-node scripts/initialize.ts"
+test = "cargo test"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,11 +320,11 @@ checksum = "3c08cb5d762c0694f74bd02c9a5b04ea53cefc496e2c27b3234acffca5cd076b"
 dependencies = [
  "anchor-lang",
  "spl-associated-token-account",
- "spl-pod",
- "spl-token",
+ "spl-pod 0.5.1",
+ "spl-token 7.0.0",
  "spl-token-2022 6.0.0",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
+ "spl-token-group-interface 0.5.0",
+ "spl-token-metadata-interface 0.6.0",
 ]
 
 [[package]]
@@ -2585,7 +2585,8 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "spl-associated-token-account-client",
- "spl-token",
+ "spl-token 7.0.0",
+ "spl-token-2022 6.0.0",
 ]
 
 [[package]]
@@ -4084,10 +4085,10 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-sysvar",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 7.0.0",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
+ "spl-token-group-interface 0.5.0",
+ "spl-token-metadata-interface 0.6.0",
  "thiserror 2.0.12",
  "zstd",
 ]
@@ -7002,7 +7003,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-associated-token-account-client",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 6.0.0",
  "thiserror 1.0.69",
 ]
@@ -7015,6 +7016,17 @@ checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
 dependencies = [
  "solana-instruction",
  "solana-pubkey",
+]
+
+[[package]]
+name = "spl-discriminator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38ea8b6dedb7065887f12d62ed62c1743aa70749e8558f963609793f6fb12bc"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator-derive",
 ]
 
 [[package]]
@@ -7062,8 +7074,17 @@ dependencies = [
  "bytemuck",
  "solana-program",
  "solana-zk-sdk",
- "spl-pod",
+ "spl-pod 0.5.1",
  "spl-token-confidential-transfer-proof-extraction",
+]
+
+[[package]]
+name = "spl-memo"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0dba2f2bb6419523405d21c301a32c9f9568354d4742552e7972af801f4bdb3"
+dependencies = [
+ "solana-program",
 ]
 
 [[package]]
@@ -7078,6 +7099,20 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey",
+]
+
+[[package]]
+name = "spl-pod"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c704c88fc457fa649ba3aabe195c79d885c3f26709efaddc453c8de352c90b87"
+dependencies = [
+ "borsh 1.5.7",
+ "bytemuck",
+ "bytemuck_derive",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-program-error 0.5.0",
 ]
 
 [[package]]
@@ -7098,6 +7133,19 @@ dependencies = [
  "solana-pubkey",
  "solana-zk-sdk",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "spl-program-error"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b28bed65356558133751cc32b48a7a5ddfc59ac4e941314630bbed1ac10532"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "solana-program",
+ "spl-program-error-derive",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7127,6 +7175,20 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a75a5f0fcc58126693ed78a17042e9dc53f07e357d6be91789f7d62aff61a4"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.3.1",
+ "spl-program-error 0.5.0",
+ "spl-type-length-value 0.5.0",
+]
+
+[[package]]
+name = "spl-tlv-account-resolution"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd99ff1e9ed2ab86e3fd582850d47a739fec1be9f4661cba1782d3a0f26805f3"
@@ -7140,10 +7202,25 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
+ "spl-discriminator 0.4.1",
+ "spl-pod 0.5.1",
+ "spl-program-error 0.6.0",
+ "spl-type-length-value 0.7.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a0f06ac7f23dc0984931b1fe309468f14ea58e32660439c1cef19456f5d0e3"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
  "thiserror 1.0.69",
 ]
 
@@ -7164,6 +7241,30 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33afcf7a47274725990c783a6e86330883cae26655ad6e2d910f765e530d2cef"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "solana-security-txt",
+ "solana-zk-token-sdk",
+ "spl-memo 5.0.0",
+ "spl-pod 0.3.1",
+ "spl-token 6.0.0",
+ "spl-token-group-interface 0.3.0",
+ "spl-token-metadata-interface 0.4.0",
+ "spl-transfer-hook-interface 0.7.0",
+ "spl-type-length-value 0.5.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token-2022"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b27f7405010ef816587c944536b0eafbcc35206ab6ba0f2ca79f1d28e488f4f"
@@ -7177,16 +7278,16 @@ dependencies = [
  "solana-security-txt",
  "solana-zk-sdk",
  "spl-elgamal-registry",
- "spl-memo",
- "spl-pod",
- "spl-token",
+ "spl-memo 6.0.0",
+ "spl-pod 0.5.1",
+ "spl-token 7.0.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation 0.2.0",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "spl-type-length-value",
+ "spl-token-group-interface 0.5.0",
+ "spl-token-metadata-interface 0.6.0",
+ "spl-transfer-hook-interface 0.9.0",
+ "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
 ]
 
@@ -7205,16 +7306,16 @@ dependencies = [
  "solana-security-txt",
  "solana-zk-sdk",
  "spl-elgamal-registry",
- "spl-memo",
- "spl-pod",
- "spl-token",
+ "spl-memo 6.0.0",
+ "spl-pod 0.5.1",
+ "spl-token 7.0.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic",
  "spl-token-confidential-transfer-proof-extraction",
  "spl-token-confidential-transfer-proof-generation 0.3.0",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
- "spl-type-length-value",
+ "spl-token-group-interface 0.5.0",
+ "spl-token-metadata-interface 0.6.0",
+ "spl-transfer-hook-interface 0.9.0",
+ "spl-type-length-value 0.7.0",
  "thiserror 2.0.12",
 ]
 
@@ -7240,7 +7341,7 @@ dependencies = [
  "solana-curve25519",
  "solana-program",
  "solana-zk-sdk",
- "spl-pod",
+ "spl-pod 0.5.1",
  "thiserror 2.0.12",
 ]
 
@@ -7268,6 +7369,19 @@ dependencies = [
 
 [[package]]
 name = "spl-token-group-interface"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8752b85a5ecc1d9f3a43bce3dd9a6a053673aacf5deb513d1cbb88d3534ffd"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.3.1",
+ "spl-program-error 0.5.0",
+]
+
+[[package]]
+name = "spl-token-group-interface"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d595667ed72dbfed8c251708f406d7c2814a3fa6879893b323d56a10bedfc799"
@@ -7280,9 +7394,23 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
+ "spl-discriminator 0.4.1",
+ "spl-pod 0.5.1",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c2318ddff97e006ed9b1291ebec0750a78547f870f62a69c56fe3b46a5d8fc"
+dependencies = [
+ "borsh 1.5.7",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.3.1",
+ "spl-program-error 0.5.0",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7300,10 +7428,26 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-type-length-value",
+ "spl-discriminator 0.4.1",
+ "spl-pod 0.5.1",
+ "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-transfer-hook-interface"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a110f33d941275d9f868b96daaa993f1e73b6806cc8836e43075b4d3ad8338a7"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.3.1",
+ "spl-program-error 0.5.0",
+ "spl-tlv-account-resolution 0.7.0",
+ "spl-type-length-value 0.5.0",
 ]
 
 [[package]]
@@ -7323,12 +7467,25 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-pubkey",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution",
- "spl-type-length-value",
+ "spl-discriminator 0.4.1",
+ "spl-pod 0.5.1",
+ "spl-program-error 0.6.0",
+ "spl-tlv-account-resolution 0.9.0",
+ "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-type-length-value"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdcd73ec187bc409464c60759232e309f83b52a18a9c5610bf281c9c6432918c"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator 0.3.0",
+ "spl-pod 0.3.1",
+ "spl-program-error 0.5.0",
 ]
 
 [[package]]
@@ -7344,8 +7501,8 @@ dependencies = [
  "solana-decode-error",
  "solana-msg",
  "solana-program-error",
- "spl-discriminator",
- "spl-pod",
+ "spl-discriminator 0.4.1",
+ "spl-pod 0.5.1",
  "thiserror 1.0.69",
 ]
 
@@ -7570,11 +7727,13 @@ dependencies = [
  "bridge_cards",
  "litesvm",
  "litesvm-token",
+ "paste",
  "serde",
  "solana-account",
  "solana-program-test",
  "solana-sdk",
  "spl-associated-token-account-client",
+ "spl-token-2022 4.0.1",
  "tokio",
 ]
 

--- a/programs/bridge_cards/src/instructions/add_or_update_merchant_destination.rs
+++ b/programs/bridge_cards/src/instructions/add_or_update_merchant_destination.rs
@@ -3,8 +3,7 @@ use crate::instructions::initialize::STATE_SEED;
 use crate::state::{BridgeCardsState, MerchantDestinationState};
 use crate::ID;
 use anchor_lang::prelude::*;
-use anchor_spl::token::TokenAccount;
-use anchor_spl::token_interface::Mint;
+use anchor_spl::token_interface::{Mint, TokenAccount};
 
 /// Seed used to derive merchant destination PDAs
 pub const MERCHANT_DESTINATION_SEED: &[u8] = b"merchant_destination";
@@ -90,7 +89,7 @@ pub struct AddOrUpdateMerchantDestination<'info> {
     /// Must use the specified mint
     /// Required permissions: None (read-only validation)
     #[account(constraint = destination_token_account.mint.key() == mint.key())]
-    pub destination_token_account: Account<'info, TokenAccount>,
+    pub destination_token_account: InterfaceAccount<'info, TokenAccount>,
 
     /// Mint of the destination token account
     /// Used for PDA derivation and account validation

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,7 +16,9 @@ spl-associated-token-account-client = "2.0.0"
 spl-token-2022 = "4.0.0"
 tokio = { version = "1", features = ["full"] }
 paste = "1.0"
-bridge_cards = { path = "../programs/bridge_cards", features = ["local"] }
+bridge_cards = { path = "../programs/bridge_cards", features = [
+  "no-entrypoint",
+] }
 anchor-lang = { version = "0.31.0", features = ["init-if-needed"] }
 anchor-spl = "0.31.0"
 account-data-trait = { path = "../account-data-trait" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,6 +16,7 @@ spl-associated-token-account-client = "2.0.0"
 spl-token-2022 = "4.0.0"
 tokio = { version = "1", features = ["full"] }
 paste = "1.0"
+# Do not load entrypoint in tests -- this ensures we will not have conflicts with the token22 program's security entrypoint.
 bridge_cards = { path = "../programs/bridge_cards", features = [
   "no-entrypoint",
 ] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,13 +7,15 @@ edition = "2021"
 anchor-client = "0.31.0"
 bincode = "2.0.1"
 litesvm = "0.6.0"
-litesvm-token = "0.6.0"
+litesvm-token = { version = "0.6.0", features = ["token-2022"] }
 serde = "1.0.219"
 solana-account = "2.2.1"
 solana-program-test = "2.2.2"
 solana-sdk = "2.2.1"
 spl-associated-token-account-client = "2.0.0"
+spl-token-2022 = "4.0.0"
 tokio = { version = "1", features = ["full"] }
+paste = "1.0"
 bridge_cards = { path = "../programs/bridge_cards", features = ["local"] }
 anchor-lang = { version = "0.31.0", features = ["init-if-needed"] }
 anchor-spl = "0.31.0"

--- a/tests/src/add_or_update_merchant_debitor_tests.rs
+++ b/tests/src/add_or_update_merchant_debitor_tests.rs
@@ -18,7 +18,7 @@ async fn test_add_merchant_debitor() {
 
     // Step 2: Create a token mint and accounts
     let (_, debitor_pk) = setup_keypair(&mut ctx);
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
 
     // Step 3: Create the merchant account
     let debitor_pda =
@@ -100,7 +100,7 @@ async fn test_add_second_debitor() {
 
     // Step 2: Create a token mint and accounts
     let (_, debitor_pk) = setup_keypair(&mut ctx);
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
 
     // First create the merchant
     let debitor_pda =
@@ -156,7 +156,7 @@ async fn test_add_second_debitor() {
 
     // Step 3: Now update the merchant with new debitor
     let (_, new_debitor_pk) = setup_keypair(&mut ctx);
-    let (_, new_mint_pk) = setup_mint(&mut ctx);
+    let new_mint_pk = setup_mint(&mut ctx);
     let new_debitor_pda = make_merchant_debitor_pda(
         TEST_MERCHANT_ID,
         &new_debitor_pk,
@@ -241,7 +241,7 @@ async fn test_update_debitor_to_false_then_back() {
     let mut ctx = setup_and_initialize();
 
     let (_, debitor_pk) = setup_keypair(&mut ctx);
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
 
     let debitor_pda =
         make_merchant_debitor_pda(TEST_MERCHANT_ID, &debitor_pk, &mint_pk, &ctx.program_id);
@@ -374,7 +374,7 @@ async fn test_non_manager_cannot_add_debitor() {
 
     // Step 3: Create a token mint and accounts
     let (_, debitor_pk) = setup_keypair(&mut ctx);
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
 
     // Try to create the merchant with non-manager
     let debitor_pda =

--- a/tests/src/add_or_update_merchant_destination_tests.rs
+++ b/tests/src/add_or_update_merchant_destination_tests.rs
@@ -16,7 +16,7 @@ async fn test_create_merchant_destination() {
     let mut ctx = setup_and_initialize();
 
     // Step 2: Create a token mint and accounts
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
     let merchant_id = 1u64;
     let (_, destination_owner_pk) = setup_keypair(&mut ctx);
 
@@ -117,7 +117,7 @@ async fn test_update_merchant_destination() {
     let mut ctx = setup_and_initialize();
 
     // Step 2: Create a token mint and accounts
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
     let merchant_id = 2u64;
     let (_, destination_pk) = setup_keypair(&mut ctx);
 
@@ -273,7 +273,7 @@ async fn test_non_admin_cannot_create_merchant() {
     let (non_admin_kp, non_admin_pk) = setup_keypair(&mut ctx);
 
     // Step 3: Create a token mint and accounts
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
     let merchant_id = 3u64;
     let (_, destination_owner_pk) = setup_keypair(&mut ctx);
 
@@ -333,7 +333,7 @@ async fn test_two_merchant_destinations() {
     let mut ctx = setup_and_initialize();
 
     let merchant_id = 4u64;
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
     let (_, destination_pk) = setup_keypair(&mut ctx);
 
     // Create token accounts for the destination

--- a/tests/src/add_or_update_user_delegate_tests.rs
+++ b/tests/src/add_or_update_user_delegate_tests.rs
@@ -18,7 +18,7 @@ async fn test_create_user_delegate() {
     let mut ctx = setup_and_initialize();
 
     // Step 2: Create a token mint and accounts
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
 
     // Create user and their token account
     let (_, user_pk) = setup_keypair(&mut ctx);
@@ -132,7 +132,7 @@ async fn test_non_manager_cannot_create_user_delegate() {
     let (non_manager_kp, non_manager_pk) = setup_keypair(&mut ctx);
 
     // Step 3: Create a token mint and accounts
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
 
     // Create user and their token account
     let (_, user_pk) = setup_keypair(&mut ctx);
@@ -201,7 +201,7 @@ async fn test_update_user_delegate() {
     let mut ctx = setup_and_initialize();
 
     // Step 2: Create a token mint and accounts
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
 
     // Create user and their token account
     let (_, user_pk) = setup_keypair(&mut ctx);

--- a/tests/src/close_account_tests.rs
+++ b/tests/src/close_account_tests.rs
@@ -19,7 +19,7 @@ async fn test_close_account_success() {
 
     // Create a merchant debitor account to close
     let (debitor_kp, debitor_pk) = setup_keypair(&mut ctx);
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
     let debitor_pda =
         make_merchant_debitor_pda(TEST_MERCHANT_ID, &debitor_pk, &mint_pk, &ctx.program_id);
 
@@ -136,7 +136,7 @@ async fn test_close_account_not_admin() {
 
     // Create a merchant debitor account to close
     let (debitor_kp, debitor_pk) = setup_keypair(&mut ctx);
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
     let debitor_pda =
         make_merchant_debitor_pda(TEST_MERCHANT_ID, &debitor_pk, &mint_pk, &ctx.program_id);
 
@@ -219,7 +219,7 @@ async fn test_close_account_invalid_pda() {
 
     // Create a merchant debitor account to close
     let (debitor_kp, debitor_pk) = setup_keypair(&mut ctx);
-    let (_, mint_pk) = setup_mint(&mut ctx);
+    let mint_pk = setup_mint(&mut ctx);
     let debitor_pda =
         make_merchant_debitor_pda(TEST_MERCHANT_ID, &debitor_pk, &mint_pk, &ctx.program_id);
 

--- a/tests/src/common/mod.rs
+++ b/tests/src/common/mod.rs
@@ -448,7 +448,13 @@ pub fn create_debit_user_instruction(
     merchant_id: u64,
     amount: u64,
 ) -> Instruction {
-    create_debit_user_instruction_with_program(ctx, accounts, merchant_id, amount, TokenProgram::Token)
+    create_debit_user_instruction_with_program(
+        ctx,
+        accounts,
+        merchant_id,
+        amount,
+        TokenProgram::Token,
+    )
 }
 
 pub fn create_debit_user_instruction_with_program(
@@ -458,7 +464,11 @@ pub fn create_debit_user_instruction_with_program(
     amount: u64,
     _token_program: TokenProgram,
 ) -> Instruction {
-    let ix_data = bridge_cards::instruction::DebitUser { merchant_id, amount }.data();
+    let ix_data = bridge_cards::instruction::DebitUser {
+        merchant_id,
+        amount,
+    }
+    .data();
 
     Instruction {
         program_id: ctx.program_id,

--- a/tests/src/common/mod.rs
+++ b/tests/src/common/mod.rs
@@ -13,14 +13,25 @@ use bridge_cards::instructions::add_or_update_merchant_manager::MERCHANT_MANAGER
 use bridge_cards::instructions::add_or_update_user_delegate::USER_DELEGATE_SEED;
 use litesvm::types::TransactionResult;
 use litesvm::LiteSVM;
-use litesvm_token::spl_token::{self, state::Mint as MintState};
-use litesvm_token::CreateAssociatedTokenAccountIdempotent;
-use solana_account::Account;
-use solana_sdk::program_pack::Pack;
-use solana_sdk::signature::Keypair;
-use solana_sdk::signature::Signer;
+use litesvm_token::*;
+use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::transaction::Transaction;
 use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TokenProgram {
+    Token,
+    Token2022,
+}
+
+impl TokenProgram {
+    pub fn program_id(&self) -> Pubkey {
+        match self {
+            TokenProgram::Token => spl_token::id(),
+            TokenProgram::Token2022 => spl_token_2022::id(),
+        }
+    }
+}
 
 pub struct Context {
     pub svm: LiteSVM,
@@ -203,37 +214,17 @@ pub fn setup_keypair(ctx: &mut Context) -> (Keypair, Pubkey) {
     (keypair, pubkey)
 }
 
-pub fn setup_mint(ctx: &mut Context) -> (Keypair, Pubkey) {
-    let mint_kp = Keypair::new();
-    let mint_pk = mint_kp.pubkey();
+pub fn setup_mint(ctx: &mut Context) -> Pubkey {
+    // Use default token program.
+    setup_mint_with_program(ctx, TokenProgram::Token)
+}
 
-    // Setup mint with 6 decimals
-    let mint = MintState {
-        mint_authority: Some(ctx.payer_pk).into(),
-        supply: 0,
-        decimals: 6,
-        is_initialized: true,
-        freeze_authority: Some(ctx.payer_pk).into(),
-    };
-
-    let mut mint_data = vec![0u8; MintState::get_packed_len()];
-    MintState::pack(mint, &mut mint_data).unwrap();
-
-    // Create mint account
-    ctx.svm
-        .set_account(
-            mint_pk,
-            Account {
-                lamports: 1_000_000_000,
-                data: mint_data,
-                owner: spl_token::id(),
-                executable: false,
-                rent_epoch: 0,
-            },
-        )
-        .unwrap();
-
-    (mint_kp, mint_pk)
+pub fn setup_mint_with_program(ctx: &mut Context, token_program: TokenProgram) -> Pubkey {
+    CreateMint::new(&mut ctx.svm, &ctx.payer_kp)
+        .token_program_id(&token_program.program_id())
+        .decimals(6)
+        .send()
+        .unwrap()
 }
 
 pub fn make_merchant_debitor_pda(
@@ -287,11 +278,31 @@ pub fn setup_merchant_debitor_and_destination(
     mint_pk: &Pubkey,
     destination_owner: &Pubkey,
 ) -> (Pubkey, Pubkey, Pubkey) {
+    setup_merchant_debitor_and_destination_with_program(
+        ctx,
+        merchant_id,
+        debitor_pk,
+        mint_pk,
+        destination_owner,
+        // Use default token program.
+        TokenProgram::Token,
+    )
+}
+
+pub fn setup_merchant_debitor_and_destination_with_program(
+    ctx: &mut Context,
+    merchant_id: u64,
+    debitor_pk: Pubkey,
+    mint_pk: &Pubkey,
+    destination_owner: &Pubkey,
+    token_program: TokenProgram,
+) -> (Pubkey, Pubkey, Pubkey) {
     let debitor_pda = make_merchant_debitor_pda(merchant_id, &debitor_pk, mint_pk, &ctx.program_id);
 
     let destination_token_account =
         CreateAssociatedTokenAccountIdempotent::new(&mut ctx.svm, &ctx.payer_kp, mint_pk)
             .owner(destination_owner)
+            .token_program_id(&token_program.program_id())
             .send()
             .unwrap();
 
@@ -437,11 +448,17 @@ pub fn create_debit_user_instruction(
     merchant_id: u64,
     amount: u64,
 ) -> Instruction {
-    let ix_data = bridge_cards::instruction::DebitUser {
-        merchant_id,
-        amount,
-    }
-    .data();
+    create_debit_user_instruction_with_program(ctx, accounts, merchant_id, amount, TokenProgram::Token)
+}
+
+pub fn create_debit_user_instruction_with_program(
+    ctx: &Context,
+    accounts: &DebitUser,
+    merchant_id: u64,
+    amount: u64,
+    _token_program: TokenProgram,
+) -> Instruction {
+    let ix_data = bridge_cards::instruction::DebitUser { merchant_id, amount }.data();
 
     Instruction {
         program_id: ctx.program_id,

--- a/tests/src/debit_user_tests.rs
+++ b/tests/src/debit_user_tests.rs
@@ -172,887 +172,50 @@ fn verify_token_account_balance(
 ) {
     match token_program {
         TokenProgram::Token => {
-            let account_info = get_spl_account::<spl_token::state::Account>(&ctx.svm, token_account)
-                .unwrap();
+            let account_info =
+                get_spl_account::<spl_token::state::Account>(&ctx.svm, token_account).unwrap();
             assert_eq!(account_info.amount, expected_amount, "{}", error_msg);
         }
         TokenProgram::Token2022 => {
-            let account_info = get_spl_account::<spl_token_2022::state::Account>(&ctx.svm, token_account)
-                .unwrap();
+            let account_info =
+                get_spl_account::<spl_token_2022::state::Account>(&ctx.svm, token_account).unwrap();
             assert_eq!(account_info.amount, expected_amount, "{}", error_msg);
         }
     }
 }
 
-parameterized_token_test!(test_debit_user_successful, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
+parameterized_token_test!(
+    test_debit_user_successful,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create the debit user instruction
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
 
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create the debit user instruction
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    // Execute the transaction
-    let result = submit_transaction(&mut ctx, debit_tx);
-    assert!(result.is_ok(), "Failed to debit user: {:?}", result.err());
-
-    // Verify the log message
-    let meta = result.unwrap();
-    let expected_log = "Instruction: DebitUser"; // Check for instruction log
-    assert!(
-        meta.logs.iter().any(|log| log.contains(expected_log)),
-        "Expected log containing '{}' not found in logs: {}",
-        expected_log,
-        meta.logs.join("\n")
-    );
-
-    // Verify user token account balance decreased
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE - DEBIT_AMOUNT,
-        token_program,
-        "User token account balance incorrect",
-    );
-
-    // Verify destination token account balance increased
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.destination_token_account,
-        DEBIT_AMOUNT,
-        token_program,
-        "Destination token account balance incorrect",
-    );
-
-    // Verify user delegate state was updated
-    let user_delegate_account = ctx
-        .svm
-        .get_account(&debit_context.user_delegate_pda)
-        .unwrap();
-    let user_delegate_state =
-        UserDelegateState::try_deserialize(&mut user_delegate_account.data.as_slice()).unwrap();
-
-    assert_eq!(
-        user_delegate_state.period_transferred_amount, DEBIT_AMOUNT,
-        "User delegate transferred amount incorrect"
-    );
-});
-
-parameterized_token_test!(test_debit_user_exceeds_max_limit, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Try to debit more than the max transfer limit
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    let excessive_amount = MAX_TRANSFER_LIMIT + 1;
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        excessive_amount,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    // Execute the transaction - should fail with ExceedsMaxTransferLimit
-    let result = submit_transaction(&mut ctx, debit_tx);
-    assert!(
-        result.is_err(),
-        "Transaction should fail due to exceeding max transfer limit"
-    );
-
-    // Verify the error matches ExceedsMaxTransferLimit
-    let err = result.err().unwrap();
-    let expected_message = ErrorCode::ExceedsMaxTransferLimit.to_string();
-    assert!(
-        err.meta
-            .logs
-            .iter()
-            .any(|log| log.contains(&expected_message)),
-        "Error should contain the expected error message {}, got {}",
-        expected_message,
-        err.meta.logs.join(", ")
-    );
-
-    // Verify user token account balance remains unchanged
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE,
-        token_program,
-        "User token account balance should remain unchanged",
-    );
-});
-
-parameterized_token_test!(test_debit_user_non_merchant_debitor, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create a different signer (not the merchant's debitor)
-    let (non_debitor_kp, non_debitor_pk) = setup_keypair(&mut ctx);
-
-    // Try to debit with non-merchant debitor
-    let debit_accounts = DebitUser {
-        debitor: non_debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &non_debitor_kp],
-    );
-
-    // Execute the transaction - should fail with constraint violation
-    let result = submit_transaction(&mut ctx, debit_tx);
-    assert!(
-        result.is_err(),
-        "Transaction should fail due to debitor constraint violation"
-    );
-
-    // Verify user token account balance remains unchanged
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE,
-        token_program,
-        "User token account balance should remain unchanged",
-    );
-});
-
-parameterized_token_test!(test_debit_user_period_limit_reset, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create the debit accounts
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    // First debit
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    let result1 = submit_transaction(&mut ctx, debit_tx);
-    assert!(result1.is_ok(), "First debit failed: {:?}", result1.err());
-
-    // Verify the log message for first debit
-    let meta1 = result1.unwrap();
-    let expected_log = "Instruction: DebitUser";
-    assert!(
-        meta1.logs.iter().any(|log| log.contains(expected_log)),
-        "Expected log containing '{}' for first debit not found: {}",
-        expected_log,
-        meta1.logs.join("\n")
-    );
-
-    // Second debit after period reset
-    let debit_ix2 = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx2 = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix2],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    // advance clock by 1 day
-    let mut new_clock = ctx.svm.get_sysvar::<Clock>();
-    new_clock.unix_timestamp += 86401;
-    new_clock.slot += 1; // Advance slot for next transaction
-    ctx.svm.set_sysvar(&new_clock);
-
-    let result2 = submit_transaction(&mut ctx, debit_tx2);
-    assert!(result2.is_ok(), "Second debit failed: {:?}", result2.err());
-
-    // Verify the log message for second debit
-    let meta2 = result2.unwrap();
-    assert!(
-        meta2.logs.iter().any(|log| log.contains(expected_log)),
-        "Expected log containing '{}' for second debit not found: {}",
-        expected_log,
-        meta2.logs.join("\n")
-    );
-
-    // Verify user token account balance decreased by 2*DEBIT_AMOUNT
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE - (DEBIT_AMOUNT * 2),
-        token_program,
-        "User token account balance incorrect after period reset",
-    );
-
-    // Verify user delegate state was reset
-    let user_delegate_account = ctx
-        .svm
-        .get_account(&debit_context.user_delegate_pda)
-        .unwrap();
-    let user_delegate_state =
-        UserDelegateState::try_deserialize(&mut user_delegate_account.data.as_slice()).unwrap();
-
-    assert_eq!(
-        user_delegate_state.period_transferred_amount, DEBIT_AMOUNT,
-        "User delegate transferred amount should be reset and then incremented again"
-    );
-});
-
-parameterized_token_test!(test_debit_user_exceeds_period_limit, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        PERIOD_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create the debit accounts
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    // First debit - half of period limit
-    let first_amount = PERIOD_TRANSFER_LIMIT / 2;
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        first_amount,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    submit_transaction(&mut ctx, debit_tx).unwrap();
-
-    // Advance slot for next transaction
-    let mut new_clock = ctx.svm.get_sysvar::<Clock>();
-    new_clock.slot += 1;
-    ctx.svm.set_sysvar(&new_clock);
-
-    // Second debit - should exceed period limit
-    let second_amount = (PERIOD_TRANSFER_LIMIT / 2) + 1;
-    let debit_ix2 = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        second_amount,
-        token_program,
-    );
-    let debit_tx2 = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix2],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    // Execute the transaction - should fail with ExceedsTransferLimitPerPeriod
-    let result = submit_transaction(&mut ctx, debit_tx2);
-    assert!(
-        result.is_err(),
-        "Transaction should fail due to exceeding period transfer limit"
-    );
-    // Verify the error matches ExceedsTransferLimitPerPeriod
-    let expected_message = ErrorCode::ExceedsTransferLimitPerPeriod.to_string();
-    let err = result.err().unwrap();
-    assert!(
-        err.meta
-            .logs
-            .iter()
-            .any(|log| log.contains(&expected_message)),
-        "Error should contain the expected error message {}, got {}",
-        expected_message,
-        err.meta.logs.join(", ")
-    );
-
-    // Verify user token account balance only reflects the first debit
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE - first_amount,
-        token_program,
-        "User token account balance should only reflect the first debit",
-    );
-});
-
-parameterized_token_test!(test_debit_user_incorrect_merchant_id, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create the debit accounts but use incorrect merchant_id
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    // Use incorrect merchant_id (different from TEST_MERCHANT_ID)
-    let incorrect_merchant_id = TEST_MERCHANT_ID + 1;
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        incorrect_merchant_id,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    // Execute the transaction - should fail due to incorrect merchant_id
-    let result = submit_transaction(&mut ctx, debit_tx);
-    assert!(
-        result.is_err(),
-        "Transaction should fail due to incorrect merchant_id"
-    );
-
-    // Verify user token account balance remains unchanged
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE,
-        token_program,
-        "User token account balance should remain unchanged",
-    );
-});
-
-parameterized_token_test!(test_debit_user_invalid_destination, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create a different destination token account
-    let (_, invalid_destination_pk) = setup_keypair(&mut ctx);
-    let invalid_destination_token_account = CreateAssociatedTokenAccountIdempotent::new(
-        &mut ctx.svm,
-        &ctx.payer_kp,
-        &debit_context.mint_pk,
-    )
-    .owner(&invalid_destination_pk)
-    .send()
-    .unwrap();
-
-    // Try to debit with invalid destination
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: invalid_destination_token_account, // Wrong destination
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    // Execute the transaction - should fail with constraint violation
-    let result = submit_transaction(&mut ctx, debit_tx);
-    assert!(
-        result.is_err(),
-        "Transaction should fail due to invalid destination account"
-    );
-
-    // Verify user token account balance remains unchanged
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE,
-        token_program,
-        "User token account balance should remain unchanged",
-    );
-});
-
-parameterized_token_test!(test_debit_user_insufficient_balance, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    // Create user with a small balance
-    let small_initial_balance = DEBIT_AMOUNT / 2; // Half of the debit amount
-
-    // Setup merchant and user delegate with custom balance
-    let mint_pk = setup_mint_with_program(&mut ctx, token_program);
-    let (debitor_kp, debitor_pk) = setup_keypair(&mut ctx);
-    let (_, destination_pk) = setup_keypair(&mut ctx);
-    let destination_token_account =
-        CreateAssociatedTokenAccountIdempotent::new(&mut ctx.svm, &ctx.payer_kp, &mint_pk)
-            .owner(&destination_pk)
-            .send()
-            .unwrap();
-
-    // Save payer details before mutable borrows
-    let payer_pk = ctx.payer_pk;
-    let payer_kp = ctx.payer_kp.insecure_clone();
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create user with small balance
-    let (user_kp, user_pk) = setup_keypair(&mut ctx);
-    let user_token_account =
-        CreateAssociatedTokenAccountIdempotent::new(&mut ctx.svm, &ctx.payer_kp, &mint_pk)
-            .owner(&user_pk)
-            .send()
-            .unwrap();
-
-    // Fund the user's token account with a small balance
-    MintTo::new(
-        &mut ctx.svm,
-        &ctx.payer_kp,
-        &mint_pk,
-        &user_token_account,
-        small_initial_balance,
-    )
-    .send()
-    .unwrap();
-
-    // Create the user delegate account
-    let user_delegate_pda = make_user_delegate_pda(
-        TEST_MERCHANT_ID,
-        &mint_pk,
-        &user_token_account,
-        &ctx.program_id,
-    );
-
-    // checked-approve the user delegate pda for the user token account
-    ApproveChecked::new(
-        &mut ctx.svm,
-        &user_kp,
-        &user_delegate_pda.pubkey,
-        &mint_pk,
-        1e18 as u64,
-    )
-    .send()
-    .unwrap();
-
-    let user_delegate_accounts = bridge_cards::accounts::AddOrUpdateUserDelegate {
-        manager: ctx.merchant_manager_kp.pubkey(),
-        manager_state: ctx.merchant_manager_state.pubkey,
-        payer: payer_pk,
-        user_token_account,
-        mint: mint_pk,
-        user_delegate_account: user_delegate_pda.pubkey,
-        system_program: System::id(),
-    };
-
-    let user_delegate_ix = create_add_or_update_user_delegate_instruction(
-        &ctx,
-        &user_delegate_accounts,
-        TEST_MERCHANT_ID,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        LIMIT_PERIOD,
-    );
-    let user_delegate_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[user_delegate_ix],
-        Some(&payer_pk),
-        &[&payer_kp, &ctx.merchant_manager_kp],
-    );
-
-    submit_transaction(&mut ctx, user_delegate_tx).unwrap();
-
-    // Try to debit more than the available balance
-    let debit_accounts = DebitUser {
-        debitor: debitor_pk,
-        payer: payer_pk,
-        user_delegate_account: user_delegate_pda.pubkey,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account,
-        destination_token_account,
-        mint: mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&payer_pk),
-        &[&payer_kp, &debitor_kp],
-    );
-
-    // Execute the transaction - should fail due to insufficient funds
-    let result = submit_transaction(&mut ctx, debit_tx);
-    assert!(
-        result.is_err(),
-        "Transaction should fail due to insufficient balance"
-    );
-
-    // Verify user token account balance remains unchanged
-    verify_token_account_balance(
-        &ctx,
-        &user_token_account,
-        small_initial_balance,
-        token_program,
-        "User token account balance should remain unchanged",
-    );
-});
-
-parameterized_token_test!(test_debit_user_incorrect_mint, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create a different mint
-    let different_mint_pk = setup_mint_with_program(&mut ctx, token_program);
-
-    // Try to debit with incorrect mint
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: different_mint_pk, // Wrong mint
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    // Execute the transaction - should fail with constraint or seed derivation error
-    let result = submit_transaction(&mut ctx, debit_tx);
-    assert!(
-        result.is_err(),
-        "Transaction should fail due to incorrect mint"
-    );
-
-    // Verify user token account balance remains unchanged
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE,
-        token_program,
-        "User token account balance should remain unchanged",
-    );
-});
-
-parameterized_token_test!(test_debit_user_exact_period_boundary, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        PERIOD_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create the debit accounts
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    // First debit - half of period limit
-    let first_amount = PERIOD_TRANSFER_LIMIT / 2;
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        first_amount,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    submit_transaction(&mut ctx, debit_tx).unwrap();
-    // Advance clock to exactly the period boundary
-    let mut new_clock = ctx.svm.get_sysvar::<Clock>();
-    new_clock.unix_timestamp += LIMIT_PERIOD as i64;
-    new_clock.slot += 1; // Advance slot for next transaction
-    ctx.svm.set_sysvar(&new_clock);
-
-    // Second debit - should work because we're exactly at the period boundary
-    let debit_ix2 = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        first_amount,
-        token_program,
-    );
-    let debit_tx2 = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix2],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
-
-    let result = submit_transaction(&mut ctx, debit_tx2);
-    assert!(
-        result.is_ok(),
-        "Transaction should succeed at exactly the period boundary: {:?}",
-        result.err()
-    );
-
-    // Verify the log message for second debit
-    let meta2 = result.unwrap();
-    let expected_log = "Instruction: DebitUser";
-    assert!(
-        meta2.logs.iter().any(|log| log.contains(expected_log)),
-        "Expected log containing '{}' for second debit at boundary not found: {}",
-        expected_log,
-        meta2.logs.join("\n")
-    );
-
-    // Verify user token account balance decreased by 2*first_amount
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE - (first_amount * 2),
-        token_program,
-        "User token account balance incorrect after period boundary reset",
-    );
-});
-
-parameterized_token_test!(test_debit_user_multiple_transactions_within_period, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
-
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
-
-    // Create the debit accounts
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
-
-    // Perform multiple small debits within the period
-    let debit_amount_small = DEBIT_AMOUNT / 5; // Small enough for multiple transactions
-    let num_transactions = 5;
-    let total_debit_amount = debit_amount_small * num_transactions;
-
-    // Ensure total is within period limit
-    assert!(
-        total_debit_amount < PERIOD_TRANSFER_LIMIT,
-        "Test setup error: total debit amount exceeds period limit"
-    );
-
-    for i in 0..num_transactions {
         let debit_ix = create_debit_user_instruction_with_program(
             &ctx,
             &debit_accounts,
             TEST_MERCHANT_ID,
-            debit_amount_small,
+            DEBIT_AMOUNT,
             token_program,
         );
         let debit_tx = create_transaction_with_payer_and_signers(
@@ -1062,174 +225,1047 @@ parameterized_token_test!(test_debit_user_multiple_transactions_within_period, |
             &[&ctx.payer_kp, &debit_context.debitor_kp],
         );
 
+        // Execute the transaction
         let result = submit_transaction(&mut ctx, debit_tx);
-        assert!(
-            result.is_ok(),
-            "Transaction {} should succeed: {:?}",
-            i + 1,
-            result.err()
-        );
+        assert!(result.is_ok(), "Failed to debit user: {:?}", result.err());
 
-        // Verify the log message for this debit
+        // Verify the log message
         let meta = result.unwrap();
-        let expected_log = "Instruction: DebitUser";
+        let expected_log = "Instruction: DebitUser"; // Check for instruction log
         assert!(
             meta.logs.iter().any(|log| log.contains(expected_log)),
-            "Expected log containing '{}' for transaction {} not found: {}",
+            "Expected log containing '{}' not found in logs: {}",
             expected_log,
-            i + 1,
             meta.logs.join("\n")
         );
 
-        // Advance both clock and slot to allow next transaction
-        let mut new_clock = ctx.svm.get_sysvar::<Clock>();
-        new_clock.unix_timestamp += 60; // 1 minute
-        new_clock.slot += 1; // Advance slot
-        ctx.svm.set_sysvar(&new_clock);
+        // Verify user token account balance decreased
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE - DEBIT_AMOUNT,
+            token_program,
+            "User token account balance incorrect",
+        );
+
+        // Verify destination token account balance increased
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.destination_token_account,
+            DEBIT_AMOUNT,
+            token_program,
+            "Destination token account balance incorrect",
+        );
+
+        // Verify user delegate state was updated
+        let user_delegate_account = ctx
+            .svm
+            .get_account(&debit_context.user_delegate_pda)
+            .unwrap();
+        let user_delegate_state =
+            UserDelegateState::try_deserialize(&mut user_delegate_account.data.as_slice()).unwrap();
+
+        assert_eq!(
+            user_delegate_state.period_transferred_amount, DEBIT_AMOUNT,
+            "User delegate transferred amount incorrect"
+        );
     }
+);
 
-    // Verify user token account balance decreased by total amount
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE - total_debit_amount,
-        token_program,
-        "User token account balance incorrect after multiple transactions",
-    );
+parameterized_token_test!(
+    test_debit_user_exceeds_max_limit,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
 
-    // Verify user delegate state accumulated all transactions
-    let user_delegate_account = ctx
-        .svm
-        .get_account(&debit_context.user_delegate_pda)
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Try to debit more than the max transfer limit
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        let excessive_amount = MAX_TRANSFER_LIMIT + 1;
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            excessive_amount,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        // Execute the transaction - should fail with ExceedsMaxTransferLimit
+        let result = submit_transaction(&mut ctx, debit_tx);
+        assert!(
+            result.is_err(),
+            "Transaction should fail due to exceeding max transfer limit"
+        );
+
+        // Verify the error matches ExceedsMaxTransferLimit
+        let err = result.err().unwrap();
+        let expected_message = ErrorCode::ExceedsMaxTransferLimit.to_string();
+        assert!(
+            err.meta
+                .logs
+                .iter()
+                .any(|log| log.contains(&expected_message)),
+            "Error should contain the expected error message {}, got {}",
+            expected_message,
+            err.meta.logs.join(", ")
+        );
+
+        // Verify user token account balance remains unchanged
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE,
+            token_program,
+            "User token account balance should remain unchanged",
+        );
+    }
+);
+
+parameterized_token_test!(
+    test_debit_user_non_merchant_debitor,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create a different signer (not the merchant's debitor)
+        let (non_debitor_kp, non_debitor_pk) = setup_keypair(&mut ctx);
+
+        // Try to debit with non-merchant debitor
+        let debit_accounts = DebitUser {
+            debitor: non_debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &non_debitor_kp],
+        );
+
+        // Execute the transaction - should fail with constraint violation
+        let result = submit_transaction(&mut ctx, debit_tx);
+        assert!(
+            result.is_err(),
+            "Transaction should fail due to debitor constraint violation"
+        );
+
+        // Verify user token account balance remains unchanged
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE,
+            token_program,
+            "User token account balance should remain unchanged",
+        );
+    }
+);
+
+parameterized_token_test!(
+    test_debit_user_period_limit_reset,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create the debit accounts
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        // First debit
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        let result1 = submit_transaction(&mut ctx, debit_tx);
+        assert!(result1.is_ok(), "First debit failed: {:?}", result1.err());
+
+        // Verify the log message for first debit
+        let meta1 = result1.unwrap();
+        let expected_log = "Instruction: DebitUser";
+        assert!(
+            meta1.logs.iter().any(|log| log.contains(expected_log)),
+            "Expected log containing '{}' for first debit not found: {}",
+            expected_log,
+            meta1.logs.join("\n")
+        );
+
+        // Second debit after period reset
+        let debit_ix2 = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx2 = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix2],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        // advance clock by 1 day
+        let mut new_clock = ctx.svm.get_sysvar::<Clock>();
+        new_clock.unix_timestamp += 86401;
+        new_clock.slot += 1; // Advance slot for next transaction
+        ctx.svm.set_sysvar(&new_clock);
+
+        let result2 = submit_transaction(&mut ctx, debit_tx2);
+        assert!(result2.is_ok(), "Second debit failed: {:?}", result2.err());
+
+        // Verify the log message for second debit
+        let meta2 = result2.unwrap();
+        assert!(
+            meta2.logs.iter().any(|log| log.contains(expected_log)),
+            "Expected log containing '{}' for second debit not found: {}",
+            expected_log,
+            meta2.logs.join("\n")
+        );
+
+        // Verify user token account balance decreased by 2*DEBIT_AMOUNT
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE - (DEBIT_AMOUNT * 2),
+            token_program,
+            "User token account balance incorrect after period reset",
+        );
+
+        // Verify user delegate state was reset
+        let user_delegate_account = ctx
+            .svm
+            .get_account(&debit_context.user_delegate_pda)
+            .unwrap();
+        let user_delegate_state =
+            UserDelegateState::try_deserialize(&mut user_delegate_account.data.as_slice()).unwrap();
+
+        assert_eq!(
+            user_delegate_state.period_transferred_amount, DEBIT_AMOUNT,
+            "User delegate transferred amount should be reset and then incremented again"
+        );
+    }
+);
+
+parameterized_token_test!(
+    test_debit_user_exceeds_period_limit,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            PERIOD_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create the debit accounts
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        // First debit - half of period limit
+        let first_amount = PERIOD_TRANSFER_LIMIT / 2;
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            first_amount,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        submit_transaction(&mut ctx, debit_tx).unwrap();
+
+        // Advance slot for next transaction
+        let mut new_clock = ctx.svm.get_sysvar::<Clock>();
+        new_clock.slot += 1;
+        ctx.svm.set_sysvar(&new_clock);
+
+        // Second debit - should exceed period limit
+        let second_amount = (PERIOD_TRANSFER_LIMIT / 2) + 1;
+        let debit_ix2 = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            second_amount,
+            token_program,
+        );
+        let debit_tx2 = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix2],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        // Execute the transaction - should fail with ExceedsTransferLimitPerPeriod
+        let result = submit_transaction(&mut ctx, debit_tx2);
+        assert!(
+            result.is_err(),
+            "Transaction should fail due to exceeding period transfer limit"
+        );
+        // Verify the error matches ExceedsTransferLimitPerPeriod
+        let expected_message = ErrorCode::ExceedsTransferLimitPerPeriod.to_string();
+        let err = result.err().unwrap();
+        assert!(
+            err.meta
+                .logs
+                .iter()
+                .any(|log| log.contains(&expected_message)),
+            "Error should contain the expected error message {}, got {}",
+            expected_message,
+            err.meta.logs.join(", ")
+        );
+
+        // Verify user token account balance only reflects the first debit
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE - first_amount,
+            token_program,
+            "User token account balance should only reflect the first debit",
+        );
+    }
+);
+
+parameterized_token_test!(
+    test_debit_user_incorrect_merchant_id,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create the debit accounts but use incorrect merchant_id
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        // Use incorrect merchant_id (different from TEST_MERCHANT_ID)
+        let incorrect_merchant_id = TEST_MERCHANT_ID + 1;
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            incorrect_merchant_id,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        // Execute the transaction - should fail due to incorrect merchant_id
+        let result = submit_transaction(&mut ctx, debit_tx);
+        assert!(
+            result.is_err(),
+            "Transaction should fail due to incorrect merchant_id"
+        );
+
+        // Verify user token account balance remains unchanged
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE,
+            token_program,
+            "User token account balance should remain unchanged",
+        );
+    }
+);
+
+parameterized_token_test!(
+    test_debit_user_invalid_destination,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create a different destination token account
+        let (_, invalid_destination_pk) = setup_keypair(&mut ctx);
+        let invalid_destination_token_account = CreateAssociatedTokenAccountIdempotent::new(
+            &mut ctx.svm,
+            &ctx.payer_kp,
+            &debit_context.mint_pk,
+        )
+        .owner(&invalid_destination_pk)
+        .send()
         .unwrap();
-    let user_delegate_state =
-        UserDelegateState::try_deserialize(&mut user_delegate_account.data.as_slice()).unwrap();
 
-    assert_eq!(
-        user_delegate_state.period_transferred_amount, total_debit_amount,
-        "User delegate transferred amount should accumulate all transactions"
-    );
-});
+        // Try to debit with invalid destination
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: invalid_destination_token_account, // Wrong destination
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
 
-parameterized_token_test!(test_debit_user_same_slot, |token_program: TokenProgram| async move {
-    // Setup the test environment
-    let mut ctx = setup_and_initialize();
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
 
-    let debit_context = setup_merchant_and_user_delegate_with_program(
-        &mut ctx,
-        MAX_TRANSFER_LIMIT,
-        PERIOD_TRANSFER_LIMIT,
-        token_program,
-    );
+        // Execute the transaction - should fail with constraint violation
+        let result = submit_transaction(&mut ctx, debit_tx);
+        assert!(
+            result.is_err(),
+            "Transaction should fail due to invalid destination account"
+        );
 
-    // Create the debit accounts
-    let debit_accounts = DebitUser {
-        debitor: debit_context.debitor_pk,
-        payer: ctx.payer_pk,
-        user_delegate_account: debit_context.user_delegate_pda,
-        debitor_state: debit_context.debitor_state_pda,
-        destination_state: debit_context.destination_state_pda,
-        user_token_account: debit_context.user_token_account,
-        destination_token_account: debit_context.destination_token_account,
-        mint: debit_context.mint_pk,
-        system_program: System::id(),
-        token_program: token_program.program_id(),
-    };
+        // Verify user token account balance remains unchanged
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE,
+            token_program,
+            "User token account balance should remain unchanged",
+        );
+    }
+);
 
-    // First debit
-    let debit_ix = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
+parameterized_token_test!(
+    test_debit_user_insufficient_balance,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
 
-    let result1 = submit_transaction(&mut ctx, debit_tx);
-    assert!(result1.is_ok(), "First debit failed: {:?}", result1.err());
+        // Create user with a small balance
+        let small_initial_balance = DEBIT_AMOUNT / 2; // Half of the debit amount
 
-    // Second debit in same slot
-    let debit_ix2 = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx2 = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix2],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
+        // Setup merchant and user delegate with custom balance
+        let mint_pk = setup_mint_with_program(&mut ctx, token_program);
+        let (debitor_kp, debitor_pk) = setup_keypair(&mut ctx);
+        let (_, destination_pk) = setup_keypair(&mut ctx);
+        let destination_token_account =
+            CreateAssociatedTokenAccountIdempotent::new(&mut ctx.svm, &ctx.payer_kp, &mint_pk)
+                .owner(&destination_pk)
+                .send()
+                .unwrap();
 
-    // Execute second transaction - should fail with ExceedsMaxTransactionsPerSlot
-    let result2 = submit_transaction(&mut ctx, debit_tx2);
-    assert!(
-        result2.is_err(),
-        "Transaction should fail due to same slot transaction"
-    );
+        // Save payer details before mutable borrows
+        let payer_pk = ctx.payer_pk;
+        let payer_kp = ctx.payer_kp.insecure_clone();
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
 
-    // Verify the error matches ExceedsMaxTransactionsPerSlot
-    let err = result2.err().unwrap();
-    let expected_message = ErrorCode::ExceedsMaxTransactionsPerSlot.to_string();
-    assert!(
-        err.meta
-            .logs
-            .iter()
-            .any(|log| log.contains(&expected_message)),
-        "Error should contain the expected error message {}, got {}",
-        expected_message,
-        err.meta.logs.join("\n")
-    );
+        // Create user with small balance
+        let (user_kp, user_pk) = setup_keypair(&mut ctx);
+        let user_token_account =
+            CreateAssociatedTokenAccountIdempotent::new(&mut ctx.svm, &ctx.payer_kp, &mint_pk)
+                .owner(&user_pk)
+                .send()
+                .unwrap();
 
-    // Verify user token account balance only reflects the first debit
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE - DEBIT_AMOUNT,
-        token_program,
-        "User token account balance should only reflect the first debit",
-    );
+        // Fund the user's token account with a small balance
+        MintTo::new(
+            &mut ctx.svm,
+            &ctx.payer_kp,
+            &mint_pk,
+            &user_token_account,
+            small_initial_balance,
+        )
+        .send()
+        .unwrap();
 
-    // Third debit in different slot should succeed
-    let mut new_clock = ctx.svm.get_sysvar::<Clock>();
-    new_clock.slot += 1;
-    ctx.svm.set_sysvar(&new_clock);
+        // Create the user delegate account
+        let user_delegate_pda = make_user_delegate_pda(
+            TEST_MERCHANT_ID,
+            &mint_pk,
+            &user_token_account,
+            &ctx.program_id,
+        );
 
-    let debit_ix3 = create_debit_user_instruction_with_program(
-        &ctx,
-        &debit_accounts,
-        TEST_MERCHANT_ID,
-        DEBIT_AMOUNT,
-        token_program,
-    );
-    let debit_tx3 = create_transaction_with_payer_and_signers(
-        &ctx,
-        &[debit_ix3],
-        Some(&ctx.payer_pk),
-        &[&ctx.payer_kp, &debit_context.debitor_kp],
-    );
+        // checked-approve the user delegate pda for the user token account
+        ApproveChecked::new(
+            &mut ctx.svm,
+            &user_kp,
+            &user_delegate_pda.pubkey,
+            &mint_pk,
+            1e18 as u64,
+        )
+        .send()
+        .unwrap();
 
-    let result3 = submit_transaction(&mut ctx, debit_tx3);
-    assert!(
-        result3.is_ok(),
-        "Third debit in different slot failed: {:?}",
-        result3.err()
-    );
+        let user_delegate_accounts = bridge_cards::accounts::AddOrUpdateUserDelegate {
+            manager: ctx.merchant_manager_kp.pubkey(),
+            manager_state: ctx.merchant_manager_state.pubkey,
+            payer: payer_pk,
+            user_token_account,
+            mint: mint_pk,
+            user_delegate_account: user_delegate_pda.pubkey,
+            system_program: System::id(),
+        };
 
-    // Verify final balance reflects two successful debits
-    verify_token_account_balance(
-        &ctx,
-        &debit_context.user_token_account,
-        INITIAL_BALANCE - (DEBIT_AMOUNT * 2),
-        token_program,
-        "User token account balance should reflect two successful debits",
-    );
-});
+        let user_delegate_ix = create_add_or_update_user_delegate_instruction(
+            &ctx,
+            &user_delegate_accounts,
+            TEST_MERCHANT_ID,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            LIMIT_PERIOD,
+        );
+        let user_delegate_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[user_delegate_ix],
+            Some(&payer_pk),
+            &[&payer_kp, &ctx.merchant_manager_kp],
+        );
+
+        submit_transaction(&mut ctx, user_delegate_tx).unwrap();
+
+        // Try to debit more than the available balance
+        let debit_accounts = DebitUser {
+            debitor: debitor_pk,
+            payer: payer_pk,
+            user_delegate_account: user_delegate_pda.pubkey,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account,
+            destination_token_account,
+            mint: mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&payer_pk),
+            &[&payer_kp, &debitor_kp],
+        );
+
+        // Execute the transaction - should fail due to insufficient funds
+        let result = submit_transaction(&mut ctx, debit_tx);
+        assert!(
+            result.is_err(),
+            "Transaction should fail due to insufficient balance"
+        );
+
+        // Verify user token account balance remains unchanged
+        verify_token_account_balance(
+            &ctx,
+            &user_token_account,
+            small_initial_balance,
+            token_program,
+            "User token account balance should remain unchanged",
+        );
+    }
+);
+
+parameterized_token_test!(
+    test_debit_user_incorrect_mint,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create a different mint
+        let different_mint_pk = setup_mint_with_program(&mut ctx, token_program);
+
+        // Try to debit with incorrect mint
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: different_mint_pk, // Wrong mint
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        // Execute the transaction - should fail with constraint or seed derivation error
+        let result = submit_transaction(&mut ctx, debit_tx);
+        assert!(
+            result.is_err(),
+            "Transaction should fail due to incorrect mint"
+        );
+
+        // Verify user token account balance remains unchanged
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE,
+            token_program,
+            "User token account balance should remain unchanged",
+        );
+    }
+);
+
+parameterized_token_test!(
+    test_debit_user_exact_period_boundary,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            PERIOD_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create the debit accounts
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        // First debit - half of period limit
+        let first_amount = PERIOD_TRANSFER_LIMIT / 2;
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            first_amount,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        submit_transaction(&mut ctx, debit_tx).unwrap();
+        // Advance clock to exactly the period boundary
+        let mut new_clock = ctx.svm.get_sysvar::<Clock>();
+        new_clock.unix_timestamp += LIMIT_PERIOD as i64;
+        new_clock.slot += 1; // Advance slot for next transaction
+        ctx.svm.set_sysvar(&new_clock);
+
+        // Second debit - should work because we're exactly at the period boundary
+        let debit_ix2 = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            first_amount,
+            token_program,
+        );
+        let debit_tx2 = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix2],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        let result = submit_transaction(&mut ctx, debit_tx2);
+        assert!(
+            result.is_ok(),
+            "Transaction should succeed at exactly the period boundary: {:?}",
+            result.err()
+        );
+
+        // Verify the log message for second debit
+        let meta2 = result.unwrap();
+        let expected_log = "Instruction: DebitUser";
+        assert!(
+            meta2.logs.iter().any(|log| log.contains(expected_log)),
+            "Expected log containing '{}' for second debit at boundary not found: {}",
+            expected_log,
+            meta2.logs.join("\n")
+        );
+
+        // Verify user token account balance decreased by 2*first_amount
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE - (first_amount * 2),
+            token_program,
+            "User token account balance incorrect after period boundary reset",
+        );
+    }
+);
+
+parameterized_token_test!(
+    test_debit_user_multiple_transactions_within_period,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create the debit accounts
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        // Perform multiple small debits within the period
+        let debit_amount_small = DEBIT_AMOUNT / 5; // Small enough for multiple transactions
+        let num_transactions = 5;
+        let total_debit_amount = debit_amount_small * num_transactions;
+
+        // Ensure total is within period limit
+        assert!(
+            total_debit_amount < PERIOD_TRANSFER_LIMIT,
+            "Test setup error: total debit amount exceeds period limit"
+        );
+
+        for i in 0..num_transactions {
+            let debit_ix = create_debit_user_instruction_with_program(
+                &ctx,
+                &debit_accounts,
+                TEST_MERCHANT_ID,
+                debit_amount_small,
+                token_program,
+            );
+            let debit_tx = create_transaction_with_payer_and_signers(
+                &ctx,
+                &[debit_ix],
+                Some(&ctx.payer_pk),
+                &[&ctx.payer_kp, &debit_context.debitor_kp],
+            );
+
+            let result = submit_transaction(&mut ctx, debit_tx);
+            assert!(
+                result.is_ok(),
+                "Transaction {} should succeed: {:?}",
+                i + 1,
+                result.err()
+            );
+
+            // Verify the log message for this debit
+            let meta = result.unwrap();
+            let expected_log = "Instruction: DebitUser";
+            assert!(
+                meta.logs.iter().any(|log| log.contains(expected_log)),
+                "Expected log containing '{}' for transaction {} not found: {}",
+                expected_log,
+                i + 1,
+                meta.logs.join("\n")
+            );
+
+            // Advance both clock and slot to allow next transaction
+            let mut new_clock = ctx.svm.get_sysvar::<Clock>();
+            new_clock.unix_timestamp += 60; // 1 minute
+            new_clock.slot += 1; // Advance slot
+            ctx.svm.set_sysvar(&new_clock);
+        }
+
+        // Verify user token account balance decreased by total amount
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE - total_debit_amount,
+            token_program,
+            "User token account balance incorrect after multiple transactions",
+        );
+
+        // Verify user delegate state accumulated all transactions
+        let user_delegate_account = ctx
+            .svm
+            .get_account(&debit_context.user_delegate_pda)
+            .unwrap();
+        let user_delegate_state =
+            UserDelegateState::try_deserialize(&mut user_delegate_account.data.as_slice()).unwrap();
+
+        assert_eq!(
+            user_delegate_state.period_transferred_amount, total_debit_amount,
+            "User delegate transferred amount should accumulate all transactions"
+        );
+    }
+);
+
+parameterized_token_test!(
+    test_debit_user_same_slot,
+    |token_program: TokenProgram| async move {
+        // Setup the test environment
+        let mut ctx = setup_and_initialize();
+
+        let debit_context = setup_merchant_and_user_delegate_with_program(
+            &mut ctx,
+            MAX_TRANSFER_LIMIT,
+            PERIOD_TRANSFER_LIMIT,
+            token_program,
+        );
+
+        // Create the debit accounts
+        let debit_accounts = DebitUser {
+            debitor: debit_context.debitor_pk,
+            payer: ctx.payer_pk,
+            user_delegate_account: debit_context.user_delegate_pda,
+            debitor_state: debit_context.debitor_state_pda,
+            destination_state: debit_context.destination_state_pda,
+            user_token_account: debit_context.user_token_account,
+            destination_token_account: debit_context.destination_token_account,
+            mint: debit_context.mint_pk,
+            system_program: System::id(),
+            token_program: token_program.program_id(),
+        };
+
+        // First debit
+        let debit_ix = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        let result1 = submit_transaction(&mut ctx, debit_tx);
+        assert!(result1.is_ok(), "First debit failed: {:?}", result1.err());
+
+        // Second debit in same slot
+        let debit_ix2 = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx2 = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix2],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        // Execute second transaction - should fail with ExceedsMaxTransactionsPerSlot
+        let result2 = submit_transaction(&mut ctx, debit_tx2);
+        assert!(
+            result2.is_err(),
+            "Transaction should fail due to same slot transaction"
+        );
+
+        // Verify the error matches ExceedsMaxTransactionsPerSlot
+        let err = result2.err().unwrap();
+        let expected_message = ErrorCode::ExceedsMaxTransactionsPerSlot.to_string();
+        assert!(
+            err.meta
+                .logs
+                .iter()
+                .any(|log| log.contains(&expected_message)),
+            "Error should contain the expected error message {}, got {}",
+            expected_message,
+            err.meta.logs.join("\n")
+        );
+
+        // Verify user token account balance only reflects the first debit
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE - DEBIT_AMOUNT,
+            token_program,
+            "User token account balance should only reflect the first debit",
+        );
+
+        // Third debit in different slot should succeed
+        let mut new_clock = ctx.svm.get_sysvar::<Clock>();
+        new_clock.slot += 1;
+        ctx.svm.set_sysvar(&new_clock);
+
+        let debit_ix3 = create_debit_user_instruction_with_program(
+            &ctx,
+            &debit_accounts,
+            TEST_MERCHANT_ID,
+            DEBIT_AMOUNT,
+            token_program,
+        );
+        let debit_tx3 = create_transaction_with_payer_and_signers(
+            &ctx,
+            &[debit_ix3],
+            Some(&ctx.payer_pk),
+            &[&ctx.payer_kp, &debit_context.debitor_kp],
+        );
+
+        let result3 = submit_transaction(&mut ctx, debit_tx3);
+        assert!(
+            result3.is_ok(),
+            "Third debit in different slot failed: {:?}",
+            result3.err()
+        );
+
+        // Verify final balance reflects two successful debits
+        verify_token_account_balance(
+            &ctx,
+            &debit_context.user_token_account,
+            INITIAL_BALANCE - (DEBIT_AMOUNT * 2),
+            token_program,
+            "User token account balance should reflect two successful debits",
+        );
+    }
+);


### PR DESCRIPTION
## Context

As an extension to https://github.com/withbridge/bridge-cards/pull/35, this PR parameterizes all tests to work for token22. 

This is achieved by using a macro to codegen token22/token table driven tests.

ℹ️ This PR only affects tests

## Considerations

* This should be safe to merge as it only affects tests, and the original PR (https://github.com/withbridge/bridge-cards/pull/35) has been approved by Zelic.